### PR TITLE
Support saving DataFrames with named expressions in SQL queries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ ThisBuild / developers := List(
 ThisBuild / scalaVersion := scala211
 
 val commonDependencies = Seq(
-  "io.tarantool"       % "cartridge-driver"                % "0.7.0",
+  "io.tarantool"       % "cartridge-driver"                % "0.7.2",
   "junit"              % "junit"                           % "4.12" % Test,
   "com.github.sbt"     % "junit-interface"                 % "0.12" % Test,
   "org.testcontainers" % "testcontainers"                  % "1.16.0" % Test,

--- a/src/main/scala/io/tarantool/spark/connector/util/StringUtils.scala
+++ b/src/main/scala/io/tarantool/spark/connector/util/StringUtils.scala
@@ -1,0 +1,32 @@
+package io.tarantool.spark.connector.util
+
+import scala.annotation.tailrec
+
+/**
+  * Provides helper methods for transforming String instances
+  *
+  * @author Alexey Kuzin
+  */
+object StringUtils {
+
+  /**
+    * Converts from camelCase to snake_case
+    * e.g.: camelCase => camel_case
+    *
+    * Borrowed from https://gist.github.com/sidharthkuruvila/3154845?permalink_comment_id=2622928#gistcomment-2622928
+    *
+    * @param name the camelCase name to convert
+    * @return snake_case version of the string passed
+    */
+  def camelToSnake(name: String): String = {
+    @tailrec
+    def go(accDone: List[Char], acc: List[Char]): List[Char] = acc match {
+      case Nil => accDone
+      case a :: b :: c :: tail if a.isUpper && b.isUpper && c.isLower =>
+        go(accDone ++ List(a, '_', b, c), tail)
+      case a :: b :: tail if a.isLower && b.isUpper => go(accDone ++ List(a, '_', b), tail)
+      case a :: tail                                => go(accDone :+ a, tail)
+    }
+    go(Nil, name.toList).mkString.toLowerCase
+  }
+}

--- a/src/test/resources/Dockerfile
+++ b/src/test/resources/Dockerfile
@@ -1,0 +1,26 @@
+FROM tgagor/centos:stream8 AS tarantool-base
+ARG TARANTOOL_VERSION=2.8
+ARG TARANTOOL_SERVER_USER="tarantool"
+ARG TARANTOOL_SERVER_UID=1000
+ARG TARANTOOL_SERVER_GROUP="tarantool"
+ARG TARANTOOL_SERVER_GID=1000
+ARG TARANTOOL_WORKDIR="/app"
+ARG TARANTOOL_RUNDIR="/tmp/run"
+ARG TARANTOOL_DATADIR="/tmp/data"
+ARG TARANTOOL_INSTANCES_FILE="./instances.yml"
+ENV TARANTOOL_WORKDIR=$TARANTOOL_WORKDIR
+ENV TARANTOOL_RUNDIR=$TARANTOOL_RUNDIR
+ENV TARANTOOL_DATADIR=$TARANTOOL_DATADIR
+ENV TARANTOOL_INSTANCES_FILE=$TARANTOOL_INSTANCES_FILE
+RUN curl -L https://tarantool.io/installer.sh | VER=$TARANTOOL_VERSION /bin/bash -s -- --repo-only && \
+    yum -y install cmake make gcc gcc-c++ git unzip tarantool tarantool-devel cartridge-cli && \
+    yum clean all
+RUN groupadd -g $TARANTOOL_SERVER_GID $TARANTOOL_SERVER_GROUP && \
+    useradd -u $TARANTOOL_SERVER_UID -g $TARANTOOL_SERVER_GID -m -s /bin/bash $TARANTOOL_SERVER_USER \
+    || true
+USER $TARANTOOL_SERVER_USER:$TARANTOOL_SERVER_GROUP
+RUN cartridge version
+
+FROM tarantool-base AS cartridge-base
+WORKDIR $TARANTOOL_WORKDIR
+CMD cartridge build && cartridge start --run-dir=$TARANTOOL_RUNDIR --data-dir=$TARANTOOL_DATADIR --cfg=$TARANTOOL_INSTANCES_FILE

--- a/src/test/resources/cartridge/replicasets.yml
+++ b/src/test/resources/cartridge/replicasets.yml
@@ -1,0 +1,37 @@
+app-router:
+  instances:
+  - router
+  roles:
+  - vshard-router
+  - crud-router
+  - app.roles.api_router
+  all_rw: false
+app-router-second:
+  instances:
+  - second-router
+  roles:
+  - vshard-router
+  - crud-router
+  - app.roles.api_router
+  all_rw: false
+s1-storage:
+  instances:
+  - s1-master
+  roles:
+  - vshard-storage
+  - crud-storage
+  - app.roles.api_storage
+  weight: 1
+  all_rw: false
+  vshard_group: default
+s2-storage:
+  instances:
+  - s2-master
+  roles:
+  - vshard-storage
+  - crud-storage
+  - app.roles.api_storage
+  weight: 1
+  all_rw: false
+  vshard_group: default
+

--- a/src/test/scala/io/tarantool/spark/connector/util/StringUtilsSpec.scala
+++ b/src/test/scala/io/tarantool/spark/connector/util/StringUtilsSpec.scala
@@ -1,0 +1,21 @@
+package io.tarantool.spark.connector.util
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class StringUtilsSpec extends AnyFlatSpec with Matchers {
+  "camelToSnake" should "process right camel case + all upper case + mixed" in {
+    StringUtils.camelToSnake("COLUMN") shouldBe "column"
+    StringUtils.camelToSnake("someColumnNameRespectingCamel") shouldBe "some_column_name_respecting_camel"
+    StringUtils.camelToSnake("columnWITHSomeALLUppercaseWORDS") shouldBe "column_with_some_all_uppercase_words"
+    StringUtils.camelToSnake("_column") shouldBe "_column"
+    StringUtils.camelToSnake("column_") shouldBe "column_"
+    StringUtils.camelToSnake("Column") shouldBe "column"
+    StringUtils.camelToSnake("Column_S") shouldBe "column_s"
+    StringUtils.camelToSnake("Column_SV") shouldBe "column_sv"
+    StringUtils.camelToSnake("Column_String") shouldBe "column_string"
+    StringUtils.camelToSnake("_columnS") shouldBe "_column_s"
+    StringUtils.camelToSnake("column1234") shouldBe "column1234"
+    StringUtils.camelToSnake("column1234string") shouldBe "column1234string"
+  }
+}


### PR DESCRIPTION
Before this patch, named expressions haven't been taken into account,
so the fields were matched only by order and not by their names in the
query.

Fixes #23 