### PR TITLE
Fix BigDecimal conversion to Spark DecimalType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ codereview.rc
 metastore_db/
 derby.log
 spark-warehouse/
+tarantoolTest/

--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,8 @@ val commonDependencies = Seq(
   "org.scalatest"      %% "scalatest"                      % "3.2.9" % Test,
   "org.scalamock"      %% "scalamock"                      % "5.1.0" % Test,
   "com.dimafeng"       %% "testcontainers-scala-scalatest" % "0.39.5" % Test,
+  "org.slf4j"          % "slf4j-api"                       % "1.7.36" % Test,
+  "ch.qos.logback"     % "logback-core"                    % "1.2.5" % Test,
   "ch.qos.logback"     % "logback-classic"                 % "1.2.5" % Test,
   "org.apache.derby"   % "derby"                           % "10.11.1.1" % Test
 )
@@ -128,8 +130,12 @@ ThisBuild / useCoursier := false
 ThisBuild / updateSbtClassifiers / useCoursier := true
 
 // Test settings
-ThisBuild / Test / fork := false
+ThisBuild / Test / fork := true
 ThisBuild / Test / parallelExecution := false
+ThisBuild / Test / logLevel := Level.Info
+ThisBuild / Test / javaOptions ++= Seq(
+  "-DlogLevel=INFO"
+)
 
 // ScalaTest
 ThisBuild / Test / logBuffered := false

--- a/src/main/scala/org/apache/spark/sql/tarantool/TarantoolSchema.scala
+++ b/src/main/scala/org/apache/spark/sql/tarantool/TarantoolSchema.scala
@@ -6,7 +6,7 @@ import io.tarantool.spark.connector.config.TarantoolConfig
 import io.tarantool.spark.connector.connection.TarantoolConnection
 import io.tarantool.spark.connector.util.ScalaToJavaHelper.toJavaSupplier
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.types.{DataType, DataTypes, StructType}
+import org.apache.spark.sql.types.{DataType, DataTypes, DecimalType, StructType}
 
 import scala.collection.JavaConverters.mapAsScalaMapConverter
 import scala.language.implicitConversions
@@ -72,7 +72,7 @@ object TarantoolFieldTypes extends Enumeration {
   val DOUBLE: TarantoolFieldType = TarantoolFieldType("double", DataTypes.DoubleType)
   val INTEGER: TarantoolFieldType = TarantoolFieldType("integer", DataTypes.LongType)
   val BOOLEAN: TarantoolFieldType = TarantoolFieldType("boolean", DataTypes.BooleanType)
-  val DECIMAL: TarantoolFieldType = TarantoolFieldType("decimal", DataTypes.createDecimalType())
+  val DECIMAL: TarantoolFieldType = TarantoolFieldType("decimal", createDecimalType())
   val UUID: TarantoolFieldType = TarantoolFieldType("uuid", DataTypes.StringType)
 
   val ARRAY: TarantoolFieldType =
@@ -82,6 +82,9 @@ object TarantoolFieldTypes extends Enumeration {
     "map",
     DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType, true)
   )
+
+  def createDecimalType(): DecimalType =
+    DecimalType.SYSTEM_DEFAULT
 
   def withNameLowerCase(name: String): Value =
     values

--- a/src/test/scala/io/tarantool/spark/connector/integration/IntegrationTests.scala
+++ b/src/test/scala/io/tarantool/spark/connector/integration/IntegrationTests.scala
@@ -7,7 +7,8 @@ class IntegrationTests
     extends Suites(
       new TarantoolConnectionSpec,
       new TarantoolSparkReadClusterTest,
-      new TarantoolSparkWriteClusterTest
+      new TarantoolSparkWriteClusterTest,
+      new TarantoolSparkWriteClusterWithHiveTest
     )
     with BeforeAndAfterAll {
   protected lazy val sqlImplicits: SQLImplicits = SharedSparkContext.spark.implicits

--- a/src/test/scala/io/tarantool/spark/connector/integration/TarantoolSparkWriteClusterTest.scala
+++ b/src/test/scala/io/tarantool/spark/connector/integration/TarantoolSparkWriteClusterTest.scala
@@ -264,56 +264,6 @@ class TarantoolSparkWriteClusterTest
         .save()
     }
   }
-
-  test("should write a Dataset to the space with decimal values", DecimalTestTag) {
-    val space = "reg_numbers"
-
-    SharedSparkContext.spark.sql("create database if not exists dl_raw")
-    SharedSparkContext.spark.sql("drop table if exists DL_RAW.reg_numbers")
-
-    SharedSparkContext.spark.sql("""
-                                   |create table if not exists DL_RAW.reg_numbers (
-                                   |     bucket_id             integer 
-                                   |    ,idreg                 decimal(38,18) 
-                                   |    ,regnum                decimal(38) 
-                                   |  ) stored as orc""".stripMargin)
-    SharedSparkContext.spark.sql("""
-                                   |insert into dl_raw.reg_numbers values 
-                                   |(null, 1085529600000.13452690000413, 404503014700028), 
-                                   |(null, 1086629600000.13452690000413, 404503015800028), 
-                                   |(null, 1087430400000.13452690000413, 304503016900085) 
-                                   |""".stripMargin)
-
-    val ds = SharedSparkContext.spark.table("dl_raw.reg_numbers")
-
-    ds.show(false)
-    ds.printSchema()
-
-    ds.write
-      .format("org.apache.spark.sql.tarantool")
-      .option("tarantool.space", space)
-      .mode(SaveMode.Overwrite)
-      .save()
-
-    val actual =
-      SharedSparkContext.spark.sparkContext.tarantoolSpace(space, Conditions.any()).collect()
-    actual.length should equal(3)
-
-    actual(0).getDecimal("idreg") should equal(
-      BigDecimal("1085529600000.134526900004130000").bigDecimal
-    )
-    actual(0).getDecimal("regnum") should equal(BigDecimal("404503014700028").bigDecimal)
-
-    actual(1).getDecimal("idreg") should equal(
-      BigDecimal("1086629600000.134526900004130000").bigDecimal
-    )
-    actual(1).getDecimal("regnum") should equal(BigDecimal("404503015800028").bigDecimal)
-
-    actual(2).getDecimal("idreg") should equal(
-      BigDecimal("1087430400000.134526900004130000").bigDecimal
-    )
-    actual(2).getDecimal("regnum") should equal(BigDecimal("304503016900085").bigDecimal)
-  }
 }
 
 case class Order(
@@ -370,5 +320,3 @@ object Order {
       cleared = true
     )
 }
-
-object DecimalTestTag extends Tag("io.tarantool.spark.integration.DecimalTest")

--- a/src/test/scala/io/tarantool/spark/connector/integration/TarantoolSparkWriteClusterWithHiveTest.scala
+++ b/src/test/scala/io/tarantool/spark/connector/integration/TarantoolSparkWriteClusterWithHiveTest.scala
@@ -1,0 +1,96 @@
+package io.tarantool.spark.connector.integration
+
+import io.tarantool.driver.api.conditions.Conditions
+import io.tarantool.spark.connector.toSparkContextFunctions
+import org.apache.spark.sql.SaveMode
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.Tag
+import org.scalatest.Suite
+
+/**
+  * @author Alexey Kuzin
+  */
+@org.scalatest.DoNotDiscover
+class TarantoolSparkWriteClusterWithHiveTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterEach { this: Suite =>
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    SharedSparkContext.setupSpark(true)
+  }
+
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+    SharedSparkContext.teardownSpark()
+  }
+
+  test("should write a Dataset to the space with decimal values", DecimalTestTag) {
+    val space = "reg_numbers"
+
+    SharedSparkContext.spark.sql("create database if not exists dl_raw")
+    SharedSparkContext.spark.sql("drop table if exists DL_RAW.reg_numbers")
+
+    SharedSparkContext.spark.sql("""
+                                   |create table if not exists DL_RAW.reg_numbers (
+                                   |     bucket_id             integer 
+                                   |    ,idreg                 decimal(38,18) 
+                                   |    ,regnum                decimal(38) 
+                                   |  ) stored as orc""".stripMargin)
+    SharedSparkContext.spark.sql("""
+                                   |insert into dl_raw.reg_numbers values 
+                                   |(null, 1085529600000.13452690000413, 404503014700028), 
+                                   |(null, 1086629600000.13452690000413, 404503015800028), 
+                                   |(null, 1087430400000.13452690000413, 304503016900085) 
+                                   |""".stripMargin)
+
+    val ds = SharedSparkContext.spark.table("dl_raw.reg_numbers")
+
+    ds.show(false)
+    ds.printSchema()
+
+    ds.write
+      .format("org.apache.spark.sql.tarantool")
+      .option("tarantool.space", space)
+      .mode(SaveMode.Overwrite)
+      .save()
+
+    val actual =
+      SharedSparkContext.spark.sparkContext.tarantoolSpace(space, Conditions.any()).collect()
+    actual.length should equal(3)
+
+    actual(0).getDecimal("idreg") should equal(
+      BigDecimal("1085529600000.134526900004130000").bigDecimal
+    )
+    actual(0).getDecimal("regnum") should equal(BigDecimal("404503014700028").bigDecimal)
+
+    actual(1).getDecimal("idreg") should equal(
+      BigDecimal("1086629600000.134526900004130000").bigDecimal
+    )
+    actual(1).getDecimal("regnum") should equal(BigDecimal("404503015800028").bigDecimal)
+
+    actual(2).getDecimal("idreg") should equal(
+      BigDecimal("1087430400000.134526900004130000").bigDecimal
+    )
+    actual(2).getDecimal("regnum") should equal(BigDecimal("304503016900085").bigDecimal)
+
+    val df = SharedSparkContext.spark.read
+      .format("org.apache.spark.sql.tarantool")
+      .option("tarantool.space", space)
+      .load()
+
+    df.count() > 0 should equal(true)
+    df.select("regnum").rdd.map(row => row.get(0)).collect() should equal(
+      Array(
+        BigDecimal("404503014700028.000000000000000000").bigDecimal,
+        BigDecimal("404503015800028.000000000000000000").bigDecimal,
+        BigDecimal("304503016900085.000000000000000000").bigDecimal
+      )
+    )
+  }
+}
+
+object DecimalTestTag extends Tag("io.tarantool.spark.integration.DecimalTest")

--- a/src/test/scala/org/apache/spark/sql/tarantool/TarantoolSchemaSpec.scala
+++ b/src/test/scala/org/apache/spark/sql/tarantool/TarantoolSchemaSpec.scala
@@ -24,7 +24,7 @@ class TarantoolSchemaSpec extends AnyFlatSpec {
         DataTypes.createStructField("lastname", StringType, true),
         DataTypes.createStructField("id", StringType, true),
         DataTypes.createStructField("age", LongType, true),
-        DataTypes.createStructField("salary", DataTypes.createDecimalType(), true),
+        DataTypes.createStructField("salary", DecimalType.SYSTEM_DEFAULT, true),
         DataTypes.createStructField("discount", DoubleType, true),
         DataTypes.createStructField("favourite_constant", DoubleType, true),
         DataTypes.createStructField("married", BooleanType, true),


### PR DESCRIPTION
 - Fix Hive test database location
 - Use DecimalType.SYSTEM_DEFAULT for DecimalType when converting decimals. Previously DecimalType.USER_DEFAULT was used.
 
 Affects #24 