### PR TITLE
Add options for configuring automatic network error retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,19 @@ libraryDependencies += "io.tarantool" %% "spark-tarantool-connector" % "0.4.0"
 
 ### Configuration properties
 
-| property-key                            | description                                          | default value   |
-| --------------------------------------- | ---------------------------------------------------- | --------------- |
-| tarantool.hosts                         | comma separated list of Tarantool hosts              | 127.0.0.1:3301  |
-| tarantool.username                      | basic authentication user                            | guest           |
-| tarantool.password                      | basic authentication password                        |                 |
-| tarantool.connectTimeout                | server connect timeout, in milliseconds              | 1000            |
-| tarantool.readTimeout                   | socket read timeout, in milliseconds                 | 1000            |
-| tarantool.requestTimeout                | request completion timeout, in milliseconds          | 2000            |
-| tarantool.connections                   | number of connections established with each host     | 1               |
-| tarantool.cursorBatchSize               | default limit for prefetching tuples in RDD iterator | 1000            |
+| property-key                  | description                                                                                     | default value  |
+|-------------------------------|-------------------------------------------------------------------------------------------------|----------------|
+| tarantool.hosts               | comma separated list of Tarantool hosts                                                         | 127.0.0.1:3301 |
+| tarantool.username            | basic authentication user                                                                       | guest          |
+| tarantool.password            | basic authentication password                                                                   |                |
+| tarantool.connectTimeout      | server connect timeout, in milliseconds                                                         | 1000           |
+| tarantool.readTimeout         | socket read timeout, in milliseconds                                                            | 1000           |
+| tarantool.requestTimeout      | request completion timeout, in milliseconds                                                     | 2000           |
+| tarantool.connections         | number of connections established with each host                                                | 1              |
+| tarantool.cursorBatchSize     | default limit for prefetching tuples in RDD iterator                                            | 1000           |
+| tarantool.retries.errorType   | configures automatic retry of requests to Tarantool cluster. Possible values: "network", "none" | none           |
+| tarantool.retries.maxAttempts | maximum number of retry attempts for each request. Mandatory if errorType set to "network"      |                |
+| tarantool.retries.delay       | delay between subsequent retries of each request. Mandatory if errorType set to "network"       |                |
 
 ### Dataset API request options
 

--- a/src/main/scala/io/tarantool/spark/connector/config/TarantoolConfig.scala
+++ b/src/main/scala/io/tarantool/spark/connector/config/TarantoolConfig.scala
@@ -1,17 +1,27 @@
 package io.tarantool.spark.connector.config
 
 import io.tarantool.driver.api.TarantoolServerAddress
+import io.tarantool.spark.connector.config.ErrorTypes.ErrorType
 import org.apache.spark.SparkConf
 
 case class Credentials(username: String, password: String) extends Serializable
 
 case class Timeouts(connect: Option[Int], read: Option[Int], request: Option[Int]) extends Serializable
 
+object ErrorTypes extends Enumeration {
+  type ErrorType = Value
+
+  val NONE, NETWORK = Value
+}
+
+case class Retries(errorType: ErrorType, retryAttempts: Option[Int], delay: Option[Int]) extends Serializable
+
 case class TarantoolConfig(
   hosts: Seq[TarantoolServerAddress],
   credentials: Option[Credentials],
   timeouts: Timeouts,
-  connections: Option[Int]
+  connections: Option[Int],
+  retries: Option[Retries]
 ) extends Serializable
 
 object TarantoolConfig {
@@ -28,6 +38,11 @@ object TarantoolConfig {
 
   private val HOSTS = PREFIX + "hosts"
   private val CONNECTIONS = PREFIX + "connections"
+  private val RETRIES = PREFIX + "retries."
+
+  private val RETRIES_ERROR_TYPE = RETRIES + "errorType"
+  private val RETRIES_ATTEMPTS = RETRIES + "maxAttempts"
+  private val RETRIES_DELAY = RETRIES + "delay"
 
   //options with spark. prefix
   private val SPARK_USERNAME = SPARK_PREFIX + USERNAME
@@ -40,12 +55,17 @@ object TarantoolConfig {
   private val SPARK_HOSTS = SPARK_PREFIX + HOSTS
   private val SPARK_CONNECTIONS = SPARK_PREFIX + CONNECTIONS
 
+  private val SPARK_RETRIES_ERROR_TYPE = SPARK_PREFIX + RETRIES_ERROR_TYPE
+  private val SPARK_RETRIES_ATTEMPTS = SPARK_PREFIX + RETRIES_ATTEMPTS
+  private val SPARK_RETRIES_DELAY = SPARK_PREFIX + RETRIES_DELAY
+
   def apply(cfg: SparkConf): TarantoolConfig =
     TarantoolConfig(
       parseHosts(cfg),
       parseCredentials(cfg),
       parseTimeouts(cfg),
-      parseIntOption(cfg, CONNECTIONS, SPARK_CONNECTIONS)
+      parseIntOption(cfg, CONNECTIONS, SPARK_CONNECTIONS),
+      parseRetries(cfg)
     )
 
   def parseCredentials(cfg: SparkConf): Option[Credentials] = {
@@ -81,6 +101,35 @@ object TarantoolConfig {
       parseIntOption(cfg, READ_TIMEOUT, SPARK_READ_TIMEOUT),
       parseIntOption(cfg, REQUEST_TIMEOUT, SPARK_REQUEST_TIMEOUT)
     )
+
+  def parseRetries(cfg: SparkConf): Option[Retries] = {
+    val strErrorType = cfg.getOption(RETRIES_ERROR_TYPE).orElse(cfg.getOption(SPARK_RETRIES_ERROR_TYPE))
+    val retryAttempts = parseIntOption(cfg, RETRIES_ATTEMPTS, SPARK_RETRIES_ATTEMPTS)
+    val retryDelay = parseIntOption(cfg, RETRIES_DELAY, SPARK_RETRIES_DELAY)
+
+    if (strErrorType.isDefined) {
+      val errorType = ErrorTypes.withName(strErrorType.get.toUpperCase)
+
+      if (errorType == ErrorTypes.NETWORK) {
+        if (retryAttempts.isEmpty) {
+          throw new IllegalArgumentException("Number of retry attempts must be specified")
+        }
+
+        if (retryDelay.isEmpty) {
+          throw new IllegalArgumentException("Delay between retry attempts must be specified")
+        }
+      }
+      Some(
+        Retries(
+          errorType,
+          retryAttempts,
+          retryDelay
+        )
+      )
+    } else {
+      None
+    }
+  }
 
   def parseIntOption(cfg: SparkConf, name: String, nameWithSparkPrefix: String): Option[Int] =
     cfg.getOption(name).orElse(cfg.getOption(nameWithSparkPrefix)).map(_.toInt)

--- a/src/main/scala/io/tarantool/spark/connector/util/ScalaToJavaHelper.scala
+++ b/src/main/scala/io/tarantool/spark/connector/util/ScalaToJavaHelper.scala
@@ -4,7 +4,8 @@ import java.util.function.{
   BiFunction => JBiFunction,
   Consumer => JConsumer,
   Function => JFunction,
-  Supplier => JSupplier
+  Supplier => JSupplier,
+  UnaryOperator => JUnaryOperator
 }
 import scala.reflect.ClassTag
 
@@ -30,6 +31,13 @@ object ScalaToJavaHelper {
     */
   def toJavaFunction[T1, R](f: T1 => R): JFunction[T1, R] = new JFunction[T1, R] {
     override def apply(t: T1): R = f.apply(t)
+  }
+
+  /**
+    * Converts a Scala {@link Function1} to a Java {@link java.util.function.UnaryOperator}
+    */
+  def toJavaUnaryOperator[R](f: R => R): JUnaryOperator[R] = new JUnaryOperator[R] {
+    override def apply(t: R): R = f.apply(t)
   }
 
   /**


### PR DESCRIPTION
New client configuration options include:
 - tarantool.retries.errorType: may be "network" or "none" (default). If set to "network", the other two options are mandatory.
 - tarantool.retries.maxAttempts: max retry attempts for a single request.
 - tarantool.retries.delay: delay between subsequent attempts (milliseconds).

Adding these options enables automatic retries of certain types of network errors that may depend on the network conditions or internal Tarantool cluster state. More information can be found in https://github.com/tarantool/cartridge-java README.

Closes #36 
Affects #35 