### PR TITLE
Add an option for specifying the field names transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,28 +38,29 @@ libraryDependencies += "io.tarantool" %% "spark-tarantool-connector" % "0.4.0"
 
 ### Configuration properties
 
-| property-key                  | description                                                                                     | default value  |
-|-------------------------------|-------------------------------------------------------------------------------------------------|----------------|
-| tarantool.hosts               | comma separated list of Tarantool hosts                                                         | 127.0.0.1:3301 |
-| tarantool.username            | basic authentication user                                                                       | guest          |
-| tarantool.password            | basic authentication password                                                                   |                |
-| tarantool.connectTimeout      | server connect timeout, in milliseconds                                                         | 1000           |
-| tarantool.readTimeout         | socket read timeout, in milliseconds                                                            | 1000           |
-| tarantool.requestTimeout      | request completion timeout, in milliseconds                                                     | 2000           |
-| tarantool.connections         | number of connections established with each host                                                | 1              |
-| tarantool.cursorBatchSize     | default limit for prefetching tuples in RDD iterator                                            | 1000           |
-| tarantool.retries.errorType   | configures automatic retry of requests to Tarantool cluster. Possible values: "network", "none" | none           |
-| tarantool.retries.maxAttempts | maximum number of retry attempts for each request. Mandatory if errorType set to "network"      |                |
-| tarantool.retries.delay       | delay between subsequent retries of each request. Mandatory if errorType set to "network"       |                |
+| property-key                  | description                                                                                                    | default value  |
+|-------------------------------|----------------------------------------------------------------------------------------------------------------|----------------|
+| tarantool.hosts               | comma separated list of Tarantool hosts                                                                        | 127.0.0.1:3301 |
+| tarantool.username            | basic authentication user                                                                                      | guest          |
+| tarantool.password            | basic authentication password                                                                                  |                |
+| tarantool.connectTimeout      | server connect timeout, in milliseconds                                                                        | 1000           |
+| tarantool.readTimeout         | socket read timeout, in milliseconds                                                                           | 1000           |
+| tarantool.requestTimeout      | request completion timeout, in milliseconds                                                                    | 2000           |
+| tarantool.connections         | number of connections established with each host                                                               | 1              |
+| tarantool.cursorBatchSize     | default limit for prefetching tuples in RDD iterator                                                           | 1000           |
+| tarantool.retries.errorType   | configures automatic retry of requests to Tarantool cluster. Possible values: "network", "none"                | none           |
+| tarantool.retries.maxAttempts | maximum number of retry attempts for each request. Mandatory if errorType is set to "network"                  |                |
+| tarantool.retries.delay       | delay between subsequent retries of each request (in milliseconds). Mandatory if errorType is set to "network" |                |
 
 ### Dataset API request options
 
-| property-key              | description                                                                                        | default value |
-|---------------------------|----------------------------------------------------------------------------------------------------|---------------|
-| tarantool.space           | Tarantool space name                                                                               |               |
-| tarantool.batchSize       | limit of records to be read or written at once                                                     | 1000          |
-| tarantool.stopOnError     | stop writing immediately after a batch fails with an exception or not all tuples are written       | true          |
-| tarantool.rollbackOnError | rollback all changes written in scope of the last batch to a replicaset where an exception occured | true          |
+| property-key                  | description                                                                                                                                                                                    | default value |
+|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| tarantool.space               | Tarantool space name. Mandatory option                                                                                                                                                         |               |
+| tarantool.batchSize           | limit of records to be read or written at once                                                                                                                                                 | 1000          |
+| tarantool.stopOnError         | stop writing immediately after a batch fails with an exception or not all tuples are written                                                                                                   | true          |
+| tarantool.rollbackOnError     | rollback all changes written in scope of the last batch to a replicaset where an exception occurred                                                                                            | true          |
+| tarantool.transformFieldNames | possible values: none (default), snake_case, lower_case, upper_case. Necessary if the field names in datasets built from Spark SQL queries does not correspond to the field names in Tarantool | none          |
 
 #### Example
 

--- a/src/main/scala/io/tarantool/spark/connector/config/WriteConfig.scala
+++ b/src/main/scala/io/tarantool/spark/connector/config/WriteConfig.scala
@@ -1,12 +1,15 @@
 package io.tarantool.spark.connector.config
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.tarantool.FieldNameTransformations
+import org.apache.spark.sql.tarantool.FieldNameTransformations.FieldNameTransformation
 
 case class WriteConfig(
   spaceName: String,
   batchSize: Int = WriteConfig.DEFAULT_BATCH_SIZE,
   stopOnError: Boolean = true,
-  rollbackOnError: Boolean = true
+  rollbackOnError: Boolean = true,
+  transformFieldNames: FieldNameTransformation = FieldNameTransformations.NONE
 ) {}
 
 object WriteConfig extends TarantoolConfigBase {
@@ -15,6 +18,7 @@ object WriteConfig extends TarantoolConfigBase {
   private val BATCH_SIZE = "batchSize"
   private val STOP_ON_ERROR = "stopOnError"
   private val ROLLBACK_ON_ERROR = "rollbackOnError"
+  private val TRANSFORM_FIELD_NAMES = "transformFieldNames"
   private val DEFAULT_BATCH_SIZE = 1000
 
   def apply(sparkConf: SparkConf, options: Option[Map[String, String]]): WriteConfig =
@@ -31,7 +35,10 @@ object WriteConfig extends TarantoolConfigBase {
         .getOrElse(true),
       rollbackOnError = getFromSparkConfOrOptions(sparkConf, options, ROLLBACK_ON_ERROR)
         .map(_.toBoolean)
-        .getOrElse(true)
+        .getOrElse(true),
+      transformFieldNames = getFromSparkConfOrOptions(sparkConf, options, TRANSFORM_FIELD_NAMES)
+        .map(s => FieldNameTransformations.withName(s.toUpperCase))
+        .getOrElse(FieldNameTransformations.NONE)
     )
 
   def apply(spaceName: String): WriteConfig =

--- a/src/main/scala/io/tarantool/spark/connector/rdd/TarantoolWriteRDD.scala
+++ b/src/main/scala/io/tarantool/spark/connector/rdd/TarantoolWriteRDD.scala
@@ -107,7 +107,8 @@ class TarantoolWriteRDD[R] private[spark] (
                 .insertMany(JavaConverters.seqAsJavaListConverter(tuples.toList).asJava, options)
         }
 
-        val tupleStream: Iterator[TarantoolTuple] = partition.map(row => rowToTuple(tupleFactory, row))
+        val tupleStream: Iterator[TarantoolTuple] =
+          partition.map(row => rowToTuple(tupleFactory, row, writeConfig.transformFieldNames))
 
         if (writeConfig.stopOnError) {
           writeSync(tupleStream, operation)

--- a/src/main/scala/org/apache/spark/sql/tarantool/FieldNameTransformations.scala
+++ b/src/main/scala/org/apache/spark/sql/tarantool/FieldNameTransformations.scala
@@ -1,0 +1,23 @@
+package org.apache.spark.sql.tarantool
+
+import io.tarantool.spark.connector.util.StringUtils
+
+/**
+  * Defines possible conversions of field names for different schema sources.
+  *
+  * @author Alexey Kuzin
+  */
+object FieldNameTransformations extends Enumeration {
+
+  case class FieldNameTransformation(transform: String => String) extends super.Val {
+    def apply(fieldName: String): String = transform(fieldName)
+  }
+
+  implicit def valueToFieldNameTransformation(x: Value): FieldNameTransformation =
+    x.asInstanceOf[FieldNameTransformation]
+
+  val NONE: FieldNameTransformation = FieldNameTransformation(identity)
+  val SNAKE_CASE: FieldNameTransformation = FieldNameTransformation(StringUtils.camelToSnake)
+  val LOWER_CASE: FieldNameTransformation = FieldNameTransformation(s => s.toLowerCase)
+  val UPPER_CASE: FieldNameTransformation = FieldNameTransformation(s => s.toUpperCase)
+}

--- a/src/test/scala/org/apache/spark/sql/tarantool/MapFunctionsSpec.scala
+++ b/src/test/scala/org/apache/spark/sql/tarantool/MapFunctionsSpec.scala
@@ -152,7 +152,7 @@ class MapFunctionsSpec extends AnyFlatSpec with Matchers {
 
   it should "convert an empty row to an empty tuple" in {
     val row = Row()
-    val tuple = MapFunctions.rowToTuple(tupleFactory, row)
+    val tuple = MapFunctions.rowToTuple(tupleFactory, row, FieldNameTransformations.SNAKE_CASE)
 
     tuple should not be null
     tuple.size should equal(0)
@@ -173,7 +173,7 @@ class MapFunctionsSpec extends AnyFlatSpec with Matchers {
       time
     )
 
-    val tuple = MapFunctions.rowToTuple(tupleFactory, row)
+    val tuple = MapFunctions.rowToTuple(tupleFactory, row, FieldNameTransformations.SNAKE_CASE)
 
     val expected = new TarantoolTupleImpl(
       Seq(
@@ -208,7 +208,7 @@ class MapFunctionsSpec extends AnyFlatSpec with Matchers {
       time
     )
 
-    val tuple = MapFunctions.rowToTuple(tupleFactory, row)
+    val tuple = MapFunctions.rowToTuple(tupleFactory, row, FieldNameTransformations.SNAKE_CASE)
     val expected = new TarantoolTupleImpl(
       Seq(
         null,
@@ -235,7 +235,7 @@ class MapFunctionsSpec extends AnyFlatSpec with Matchers {
       time
     )
 
-    val tuple = MapFunctions.rowToTuple(tupleFactory, row)
+    val tuple = MapFunctions.rowToTuple(tupleFactory, row, FieldNameTransformations.NONE)
     val expected = new TarantoolTupleImpl(
       Seq(
         null,


### PR DESCRIPTION
New option for dataset write operations: "tarantool.transformFieldNames". Possible values: "none" (default), "snake_case", "lower_case", "upper_case". Option values other than the default one are necessary in the cases when the field names are taken either from an auto-generated schema from a class, or from a Spark SQL query, view or table.

Fixes #38 